### PR TITLE
Use deterministic hashing for verification tokens

### DIFF
--- a/src/main/scala/com/iscs/ratingbunny/Server.scala
+++ b/src/main/scala/com/iscs/ratingbunny/Server.scala
@@ -83,10 +83,10 @@ object Server:
       new AuthLoginImpl(userCollCodec, hasher, token)
 
   private def getUserRepoSvc[F[_]: Async](db: MongoDatabase[F]): F[UserRepo[F]] =
-    for userCollCodec <- db.getCollectionWithCodec[UserDoc](usersCollection)
-    yield
-      val hasher = BcryptHasher.make[F](cost = 12)
-      new UserRepoImpl(userCollCodec, hasher)
+    for
+      userCollCodec <- db.getCollectionWithCodec[UserDoc](usersCollection)
+      repo          <- UserRepoImpl.make[F](userCollCodec)
+    yield repo
 
   private def getTokenIssuerSvc[F[_]: Async](
       redis: RedisCommands[F, String, String],

--- a/src/main/scala/com/iscs/ratingbunny/util/DeterministicHash.scala
+++ b/src/main/scala/com/iscs/ratingbunny/util/DeterministicHash.scala
@@ -1,0 +1,12 @@
+package com.iscs.ratingbunny.util
+
+import java.security.MessageDigest
+import java.nio.charset.StandardCharsets
+
+object DeterministicHash:
+  def sha256(s: String): String =
+    MessageDigest
+      .getInstance("SHA-256")
+      .digest(s.getBytes(StandardCharsets.UTF_8))
+      .map("%02x" format _)
+      .mkString


### PR DESCRIPTION
## Summary
- Use SHA-256 for verification token hashing and query by hashed token
- Store deterministic verification hashes during signup
- Ensure unique index on verificationTokenHash
- Compute verification token hash within effect via EitherT.liftF

## Testing
- `sbt test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc5994e3883328eca1385c5da7bba