### PR TITLE
Store billing info by user handle

### DIFF
--- a/src/main/scala/com/iscs/ratingbunny/domains/AuthCheck.scala
+++ b/src/main/scala/com/iscs/ratingbunny/domains/AuthCheck.scala
@@ -51,7 +51,7 @@ final class AuthCheckImpl[F[_]: Async](
         billing match
           case Some(details) =>
             val doc = BillingInfo(
-              userId = user._id,
+              userId = user.userid,
               gateway = details.gateway,
               helcim = details.helcim,
               address = details.address,

--- a/src/main/scala/com/iscs/ratingbunny/domains/package.scala
+++ b/src/main/scala/com/iscs/ratingbunny/domains/package.scala
@@ -211,7 +211,7 @@ package object domains:
     given Codec[Address] = deriveCodec
 
   final case class BillingInfo(
-      userId: ObjectId,
+      userId: String,
       gateway: BillingGateway = BillingGateway.Helcim,
       helcim: HelcimAccount, // required when gateway=Helcim
       address: Address,

--- a/src/test/scala/com/iscs/ratingbunny/domains/AuthCheckSpec.scala
+++ b/src/test/scala/com/iscs/ratingbunny/domains/AuthCheckSpec.scala
@@ -176,7 +176,7 @@ class AuthCheckSpec extends CatsEffectSuite with EmbeddedMongo with QuerySetup:
         _   <- IO(assert(res.exists(_.userid.nonEmpty), s"expected success but got $res"))
         storedUser <- users.find(feq("email", "alice@example.com")).first
         billingDoc <- storedUser match
-          case Some(u) => billingC.find(feq("userId", u._id)).first
+          case Some(u) => billingC.find(feq("userId", u.userid)).first
           case None    => IO.pure(None)
         countB <- billingC.count
       yield


### PR DESCRIPTION
## Summary
- store billing info records using the application's user handle instead of the Mongo ObjectId to simplify codecs
- update billing persistence and lookup logic to use the new identifier
- adjust the signup spec to reflect the string-based lookup

## Testing
- not run (sbt is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d73dc7bb508332a43b6900f353cc5f