### PR TITLE
Store contact emails with unique ids and publish correlation IDs

### DIFF
--- a/src/main/scala/com/iscs/ratingbunny/domains/EmailContact.scala
+++ b/src/main/scala/com/iscs/ratingbunny/domains/EmailContact.scala
@@ -59,8 +59,8 @@ class EmailContactImpl[F[_]: MonadCancelThrow: Sync](
           fieldEmail   := email,
           fieldSubject := subject,
           fieldMsg     := msg,
-          fieldCreationDate := BsonValue.BDateTime(Instant.now),
-          fieldLastModified := BsonValue.BDateTime(Instant.now)
+          fieldCreationDate := Instant.now(),
+          fieldLastModified := Instant.now()
         )
       )
     yield doc

--- a/src/main/scala/com/iscs/ratingbunny/messaging/EmailPublisher.scala
+++ b/src/main/scala/com/iscs/ratingbunny/messaging/EmailPublisher.scala
@@ -2,24 +2,22 @@ package com.iscs.ratingbunny.messaging
 
 import cats.implicits.*
 import cats.effect.{Async, Resource}
-import dev.profunktor.fs2rabbit.config.declaration.{DeclarationExchangeConfig, DeclarationQueueConfig}
+import dev.profunktor.fs2rabbit.config.declaration.*
 import dev.profunktor.fs2rabbit.interpreter.RabbitClient
 import dev.profunktor.fs2rabbit.model.*
 import io.circe.syntax.*
 
 object EmailPublisher:
-  val Exchange: ExchangeName        = ExchangeName("rb.email")
-  val Queue: QueueName              = QueueName("rb.email.jobs")
-  val ContactRoutingKey: RoutingKey = RoutingKey("email.contact")
-  val VerifyRoutingKey: RoutingKey  = RoutingKey("email.verify_signup")
+  private val Exchange: ExchangeName        = ExchangeName("rb.email")
+  private val Queue: QueueName              = QueueName("rb.email.jobs")
+  private val ContactRoutingKey: RoutingKey = RoutingKey("email.contact")
+  private val VerifyRoutingKey: RoutingKey  = RoutingKey("email.verify_signup")
 
-  def setup[F[_]: Async](client: RabbitClient[F]): Resource[F, Unit] =
+  private def setup[F[_]: Async](client: RabbitClient[F]): Resource[F, Unit] =
     client.createConnectionChannel.evalMap { implicit ch =>
       for
-        _ <- client.declareExchange(
-          DeclarationExchangeConfig.default(Exchange, ExchangeType.Topic).copy(durable = true)
-        )
-        _ <- client.declareQueue(DeclarationQueueConfig.default(Queue).copy(durable = true))
+        _ <- client.declareExchange(DeclarationExchangeConfig.default(Exchange, ExchangeType.Topic).withDurable)
+        _ <- client.declareQueue(DeclarationQueueConfig.default(Queue).withDurable)
         _ <- client.bindQueue(Queue, Exchange, ContactRoutingKey)
         _ <- client.bindQueue(Queue, Exchange, VerifyRoutingKey)
       yield ()

--- a/src/test/scala/com/iscs/ratingbunny/domains/EmailContactSpec.scala
+++ b/src/test/scala/com/iscs/ratingbunny/domains/EmailContactSpec.scala
@@ -3,14 +3,11 @@ package com.iscs.ratingbunny.domains
 import cats.effect.IO
 import cats.effect.unsafe.IORuntime
 import com.iscs.ratingbunny.messaging.EmailJob
-import com.typesafe.scalalogging.Logger
 import mongo4cats.bson.Document
-import mongo4cats.bson.syntax.*
 import mongo4cats.client.MongoClient
 import mongo4cats.collection.MongoCollection
 import mongo4cats.database.MongoDatabase
 import mongo4cats.embedded.EmbeddedMongo
-import mongo4cats.models.collection.UpdateOptions
 import org.mongodb.scala.model.*
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec
@@ -19,50 +16,26 @@ import scala.concurrent.Future
 
 class EmailContactSpec extends AsyncWordSpec with Matchers with EmbeddedMongo:
 
-  private val L = Logger[this.type]
-
   override val mongoPort: Int = 12348
-  private val field_id        = "_id"
   private val noopPublish: EmailJob => IO[Unit] = _ => IO.unit
-
-  private val emailDoc = Document(
-    "name"    := "John Doe",
-    "_id"     := "john.doe@example.com",
-    "subject" := "Test Subject",
-    "msg"     := "This is a test message."
-  )
 
   "embedded MongoDB" when:
     "sending email" should:
-      "saveEmail should return email when validation succeeds and update is successful" in:
+      "saveEmail should return email when validation succeeds and insert is successful" in:
         withEmbeddedMongoClient: client =>
           for
             db      <- setupTestDatabase("test", client)
             emailFx <- setupTestCollection(db, "mock")
-            _ <- emailFx
-              .insertOne(emailDoc)
-              .attempt
-              .flatMap:
-                case Left(e) =>
-                  IO(L.error(s"failed to insert $emailDoc")) >> IO.raiseError(e)
-                case Right(_) =>
-                  IO(L.info(s"succeeded insert $emailDoc"))
             emailContact = new EmailContactImpl[IO](emailFx, noopPublish)
             name         = "John Doe"
             email        = "john.doe@example.com"
             subject      = "Test Subject"
             msg          = "This is a test message."
-            result    <- emailContact.saveEmail(name, email, subject, msg)
-            asDoc     <- emailContact.makeDoc(name, email, subject, msg)
-            updateDoc <- emailContact.makeUpdateDoc(asDoc)
-            emailUpdateResult <- emailFx.updateOne(
-              Filters.eq(field_id, email),
-              updateDoc,
-              UpdateOptions().upsert(true)
-            )
+            result <- emailContact.saveEmail(name, email, subject, msg)
+            stored <- emailFx.find(Filters.eq("email", email)).first
           yield
-            emailUpdateResult.getModifiedCount shouldBe 1L
             result shouldBe email
+            stored.map(_.getString("email").get) shouldBe Some(email)
 
       "saveEmail should return 'Invalid' message when validation fails" in:
         withEmbeddedMongoClient: client =>
@@ -77,7 +50,7 @@ class EmailContactSpec extends AsyncWordSpec with Matchers with EmbeddedMongo:
             result <- emailContact.saveEmail(name, invalidEmail, subject, msg)
           yield result shouldBe s"Invalid: $invalidEmail"
 
-      "updateMsg should correctly update and return the email address" in:
+      "saveEmail should create a new document for repeat emails" in:
         withEmbeddedMongoClient: client =>
           for
             db      <- setupTestDatabase("test", client)
@@ -87,9 +60,11 @@ class EmailContactSpec extends AsyncWordSpec with Matchers with EmbeddedMongo:
             email        = "jane.doe@example.com"
             subject      = "Another Test"
             msg          = "This is another test message."
-            result <- emailContact.saveEmail(name, email, subject, msg)
+            _ <- emailContact.saveEmail(name, email, subject, msg)
+            _ <- emailContact.saveEmail(name, email, subject, msg)
+            count <- emailFx.count(Filters.eq("email", email))
           yield
-            result shouldBe email
+            count shouldBe 2L
 
       "saveEmail should surface failure when publish fails" in:
         withEmbeddedMongoClient: client =>


### PR DESCRIPTION
### Motivation

- Change contact message storage so each submission becomes its own document with a generated ObjectId instead of upserting by email.
- Preserve the caller-facing behavior of returning the submitted email while providing the inserted document id as a correlation id to downstream email publish jobs.
- Ensure timestamps and the email field are stored on each document so messages are queryable by email and auditable.

### Description

- Add an `email` field and creation/lastModified `BDateTime` timestamps to the contact document created by `makeDoc`.
- Replace the previous `updateOne`/upsert flow with `insertOne` in `EmailContactImpl`, returning the inserted ObjectId (hex) and logging insert duration.
- Publish `EmailJob` for contact messages with `correlationId` set to the inserted ObjectId when present, but respond to HTTP callers with the email string.
- Update `EmailContactSpec` to assert inserted documents and to expect multiple inserts (count) for repeated submissions rather than an upsert/modify result.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69695568dd008332871a014ead94c893)